### PR TITLE
update payment_method zone association

### DIFF
--- a/app/decorators/solidus_payment_method_by_zone/spree/payment_method_decorator.rb
+++ b/app/decorators/solidus_payment_method_by_zone/spree/payment_method_decorator.rb
@@ -6,12 +6,11 @@ module SolidusPaymentMethodByZone
       extend ActiveSupport::Concern
 
       included do
-        has_many :payment_method_zones, dependent: :destroy
-        has_many :zones, through: :payment_method_zones
+        has_and_belongs_to_many :zones, join_table: 'spree_payment_method_zones'
 
         scope :available_to_address, ->(address) do
-          left_joins(:payment_method_zones).where(spree_payment_method_zones: {
-              zone_id: [nil] + ::Spree::Zone.for_address(address).pluck(:id)
+          left_joins(:zones).where(spree_zones: {
+              id: [nil] + ::Spree::Zone.for_address(address).pluck(:id)
           }).distinct
         end
       end

--- a/app/decorators/solidus_payment_method_by_zone/spree/zone_decorator.rb
+++ b/app/decorators/solidus_payment_method_by_zone/spree/zone_decorator.rb
@@ -6,8 +6,7 @@ module SolidusPaymentMethodByZone
       extend ActiveSupport::Concern
 
       included do
-        has_many :payment_method_zones, dependent: :destroy
-        has_many :payment_methods, through: :payment_method_zones
+        has_and_belongs_to_many :payment_methods, join_table: 'spree_payment_method_zones'
       end
 
     end

--- a/app/overrides/spree/admin/payment_methods/_form/add_zones.html.erb.deface
+++ b/app/overrides/spree/admin/payment_methods/_form/add_zones.html.erb.deface
@@ -4,15 +4,13 @@
     <%= f.field_container :zones do %>
       <%= f.label :zones, t('spree.admin.payment_method_zones') %>
       <br>
-      <% if f.object.persisted? %>
-        <% payment_method_zones = f.object.zones.to_a %>
-        <% Spree::Zone.all.each do |zone| %>
-          <%= label_tag do %>
-            <%= check_box_tag('payment_method[zone_ids][]', zone.id, payment_method_zones.include?(zone)) %>
-            <%= zone.name %>
-          <% end %>
-          <br>
+      <% payment_method_zones = f.object.zones.to_a %>
+      <% Spree::Zone.all.each do |zone| %>
+        <%= label_tag do %>
+          <%= check_box_tag('payment_method[zone_ids][]', zone.id, payment_method_zones.include?(zone)) %>
+          <%= zone.name %>
         <% end %>
+        <br>
       <% end %>
       <%= error_message_on :shipping_method, :zone_id %>
     <% end %>

--- a/spec/features/admin/payment_methods_spec.rb
+++ b/spec/features/admin/payment_methods_spec.rb
@@ -6,12 +6,23 @@ describe 'Payment methods admin page', type: :feature, js: true do
   stub_authorization!
 
   context 'when create new payment method' do
+    let!(:mexico) { create(:zone, name: 'Mexico') }
+
     before do
       visit spree.new_admin_payment_method_path
     end
 
     it 'render correctly' do
       expect(page).to have_content(I18n.t('spree.new_payment_method'))
+    end
+
+    it 'succesful create payment method' do
+      fill_in 'Name', with: 'Test Payment Method'
+      within '#payment_method_zones_field' do
+        check 'Mexico'
+      end
+      click_on('Create')
+      expect(page).to have_content("successfully created!")
     end
   end
 end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -7,16 +7,14 @@ describe Spree::Order, type: :model do
   let(:usa) { Spree::Country.find_by(iso: 'US') }
   let(:us_zone) { create(:zone) }
   let(:mx_zone) { create(:zone) }
-  let(:us_payment_method) { create(:check_payment_method, name: 'US method') }
-  let(:mx_payment_method) { create(:check_payment_method, name: 'MX method') }
+  let!(:us_payment_method) { create(:check_payment_method, name: 'US method', zones: [us_zone]) }
+  let!(:mx_payment_method) { create(:check_payment_method, name: 'MX method', zones: [mx_zone]) }
   let(:order) { create(:order_with_totals) }
 
   before(:each) do
     order.line_items << create(:line_item)
     us_zone.members.create(zoneable: usa)
     mx_zone.members.create(zoneable: mx)
-    us_payment_method.payment_method_zones.create(zone: us_zone)
-    mx_payment_method.payment_method_zones.create(zone: mx_zone)
   end
 
   describe 'available_payment_methods' do
@@ -50,7 +48,8 @@ describe Spree::Order, type: :model do
 
         before do
           ja_zone.members.create(zoneable: state)
-          mx_payment_method.payment_method_zones.create(zone: ja_zone)
+          mx_payment_method.zones.push(ja_zone)
+          mx_payment_method.save
         end
 
         it 'must include unique payment method' do


### PR DESCRIPTION
We are getting a `ActiveRecord::HasManyThroughOrderError` in payment method admin forms even when the order how is defined associations is correct, using a `has_and_belongs_to_many` instead fix the error.